### PR TITLE
Remove mobile tap highlight from interactive elements

### DIFF
--- a/common/styles.css
+++ b/common/styles.css
@@ -3,6 +3,8 @@
     margin: 0;
     padding: 0;
     box-sizing: border-box;
+    /* Remove blue tap highlight on mobile */
+    -webkit-tap-highlight-color: transparent;
 }
 
 :root {
@@ -111,6 +113,8 @@ nav {
     z-index: 10;
     position: relative;
     border-radius: 50%;
+    /* Remove mobile tap highlight */
+    -webkit-tap-highlight-color: transparent;
 }
 
 .logo-icon-link:focus, .logo-icon-link:hover {
@@ -132,6 +136,9 @@ nav {
     text-transform: uppercase;
     letter-spacing: 0.05em;
     transition: color 0.3s ease;
+    /* Remove mobile tap highlight */
+    -webkit-tap-highlight-color: transparent;
+    outline: none;
 }
 
 .nav-links a:hover {
@@ -170,6 +177,9 @@ nav {
     display: none;
     cursor: pointer;
     z-index: 1002;
+    /* Remove mobile tap highlight */
+    -webkit-tap-highlight-color: transparent;
+    outline: none;
 }
 
 body.nav-active .burger {
@@ -458,6 +468,9 @@ footer {
         padding: 1.2rem 1.5rem;
         text-transform: none;
         font-size: 1rem;
+        /* Remove mobile tap highlight */
+        -webkit-tap-highlight-color: transparent;
+        outline: none;
     }
 
     /* Mobile active navigation state */
@@ -512,6 +525,9 @@ footer {
         font-weight: 400;
         cursor: pointer;
         line-height: 1;
+        /* Remove mobile tap highlight */
+        -webkit-tap-highlight-color: transparent;
+        outline: none;
     }
 }
 


### PR DESCRIPTION
Added -webkit-tap-highlight-color: transparent and outline: none to various interactive elements to eliminate the blue tap highlight on mobile devices, improving the touch experience.